### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # HMRefresh 
 [![Build Status](https://travis-ci.org/itheima-developer/HMRefresh.svg?branch=master)](https://travis-ci.org/itheima-developer/HMRefresh)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/HMRefresh.svg)](https://img.shields.io/cocoapods/v/HMRefresh.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/HMRefresh.svg)](https://img.shields.io/cocoapods/v/HMRefresh.svg)
 [![Platform](https://img.shields.io/cocoapods/p/HMRefresh.svg?style=flat)](http://cocoadocs.org/docsets/HMRefresh)
 
 轻量级的上拉／下拉刷新控件


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
